### PR TITLE
white: octopus-oc-checksumsq: white labeling + obsolete #python2.7 re…

### DIFF
--- a/cdt_checksumsq/checksums_interface.py
+++ b/cdt_checksumsq/checksums_interface.py
@@ -20,7 +20,7 @@ class ChecksumsQueueClient(QueueRPC):
     def basic_args(self, parser = None):
         parser = super(ChecksumsQueueClient, self).basic_args(parser)
         parser.add_argument('--queue-cnt', help = 'cdtcontents queue name', default = getenv('AMQP_CNT_QUEUE', queue_cnt_name))
-        # SII-13216 Overriding default exchange value for message duplication support
+        # Overriding default exchange value for message duplication support
         parser.set_defaults(exchange='cdt.dlartifacts.input')
         return parser
 
@@ -44,7 +44,7 @@ class ChecksumsQueueClient(QueueRPC):
         return usual
 
 
-# A.Knyazev, SII-10060: 'artifact_deliverable' default value has been changed to 'None' 
+# 'artifact_deliverable' default value has been changed to 'None' 
 #   otherwise we may occasionly enable forbidden distributive
 
 class ChecksumsQueueServer(QueueApplication):

--- a/chkreg.py
+++ b/chkreg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python3
 
 import argparse
 from cdt_checksumsq.checksums_interface import ChecksumsQueueClient
@@ -16,7 +16,7 @@ parser.add_argument('--loctype', help='Location type, default: NXS', default='NX
 parser.add_argument('--revision', help='SVN revision', default=None)
 parser.add_argument('--depth', type=int, help='File registration depth, default: 0', default=0)
 
-#A.Knyazev, SII-10060: these two parameters added for possibility to register in Mongo correctly with 
+#these two parameters added for possibility to register in Mongo correctly with 
 # deploying deny/allow mechanism
 parser.add_argument('--parent', help='Parent list: JSON-parsable string', default=None)
 parser.add_argument('--artifact-deliverable', help="Delivery enabled", default=None)


### PR DESCRIPTION
- `#!/usr/bin/python2.7` ==> `python3`
- white-labeling comments